### PR TITLE
Feature odalic ui support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ local.properties
 .loadpath
 .springBeans
 target/
+.factorypath
 
 # External tool builders
 .externalToolBuilders/

--- a/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
+++ b/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
@@ -355,4 +355,8 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
     this.endPointUrl = sparql;
   }
 
+  public void setPublicUrlPrefix(String prefix) {
+    this.publicUrlPrefix = prefix; 
+  }
+
 }

--- a/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
+++ b/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
@@ -351,4 +351,8 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 		this.confFile = confFile;
 	}
 
+  public void setEndpointUrl(String sparql) {
+    this.endPointUrl = sparql;
+  }
+
 }

--- a/src/main/java/org/dvcama/lodview/controllers/StaticController.java
+++ b/src/main/java/org/dvcama/lodview/controllers/StaticController.java
@@ -34,7 +34,7 @@ public class StaticController {
 		this.messageSource = messageSource;
 	}
 
-	@RequestMapping(value = "/")
+	@RequestMapping(value = "/home")
 	public String home(HttpServletRequest req, HttpServletResponse res, Model model, Locale locale, @CookieValue(value = "colorPair", defaultValue = "") String colorPair) {
 		colorPair = conf.getRandomColorPair();
 		Cookie c = new Cookie("colorPair", colorPair);

--- a/src/main/java/org/dvcama/lodview/controllers/UniversalResourceController.java
+++ b/src/main/java/org/dvcama/lodview/controllers/UniversalResourceController.java
@@ -81,7 +81,13 @@ public class UniversalResourceController {
 	}
 
 	public Object resource(ConfigurationBean conf, ModelMap model, HttpServletRequest req, HttpServletResponse res, Locale locale, String output, String forceIRI, String sparql, String prefix, String colorPair) throws UnsupportedEncodingException {
-	    conf.setEndpointUrl(sparql);
+  	    if (sparql != null) {  
+  	      conf.setEndpointUrl(sparql);
+  	    }
+  	  
+  	    if (prefix != null) {
+  	      conf.setPublicUrlPrefix(prefix);
+  	    }
 	  
 	    model.addAttribute("conf", conf);
 

--- a/src/main/webapp/WEB-INF/conf.ttl
+++ b/src/main/webapp/WEB-INF/conf.ttl
@@ -75,7 +75,7 @@
 ##	to the HTML representation of the resources, live it blank if you want to 
 ##  use the "pure content negotiation mode", WARNING use suffix OR prefix, not both
 	
-	conf:httpRedirectSuffix ".html"; ## or eg. ".html";
+	##conf:httpRedirectSuffix ".html"; ## or eg. ".html";
 	##conf:httpRedirectPrefix "/page/"; ## or eg. "";
 
 	##conf:httpRedirectExcludeList ""; 	## a comma separeted list of regex to match which resources will use "pure content negotiation mode"


### PR DESCRIPTION
From now the feature demonstrated in the demo at lodview.it should actually be available (direct IRI passing, together with SPARQL endpoint URI and publishing prefix).

The implementation is a bit hacked. For stable implementation it would be nice to contact the original authors and ask them how did they implement the additional demo features (and if they would be so nice to share them).
